### PR TITLE
Support rich media sharing in App Link

### DIFF
--- a/app_link.module
+++ b/app_link.module
@@ -60,8 +60,8 @@ function app_link_bounce($applink) {
   }
 
   $metatags = array(
-    '<meta charset="utf-8">',
-    '<title>' . t('Mobile App') . '</title>',
+    'charset' => '<meta charset="utf-8">',
+    'title' => '<title>' . t('Mobile App') . '</title>',
   );
 
   // Allow other modules to hook and alter the data set.
@@ -404,7 +404,7 @@ function app_link_get_meta_tags($url) {
 
   preg_match('/<title.+<\/title>/si', $head, $match2);
   if (!empty($match2[0])) {
-    $tags[] = $match2[0];
+    $tags['title'] = $match2[0];
   }
 
   // Grab Meta tags and Link canonical.

--- a/app_link.module
+++ b/app_link.module
@@ -74,10 +74,11 @@ function app_link_bounce($applink) {
   );
   drupal_alter('applink_info', $applink);
 
-  $no_fallback_url = url('', array('absolute' => TRUE));
+  $base_url = url('', array('absolute' => TRUE));
   if (!empty($applink['platform_data']['app_link_platform_fallback']['meta_fetch']) &&
     !empty($applink['fallback_url']) &&
-    ($applink['fallback_url'] !== $no_fallback_url)
+    // Security: Only grab metatags from this current site.
+    strpos($applink['fallback_url'], $base_url) === 0
   ) {
     $metatags = app_link_get_meta_tags($applink['fallback_url']);
     $applink['metatags'] = array_merge($applink['metatags'], $metatags);

--- a/app_link.module
+++ b/app_link.module
@@ -31,7 +31,9 @@ function app_link_theme($existing, $type, $theme, $path) {
       'variables' => array(
         'platform_info' => '',
         'platform_data' => '',
+        'fallback_url' => '',
         'scripts' => array(),
+        'metatags' => array(),
       ),
       'path' => $path . '/templates',
       'template' => 'app-link',
@@ -57,12 +59,18 @@ function app_link_bounce($applink) {
     }
   }
 
+  $metatags = array(
+    '<meta charset="utf-8">',
+    '<title>' . t('Mobile App') . '</title>',
+  );
+
   // Allow other modules to hook and alter the data set.
   $applink = array(
     'platform_info' => $platform_info,
     'platform_data' => $platform_data,
     'fallback_url' => $fallback_url,
     'scripts' => $scripts,
+    'metatags' => $metatags,
   );
   drupal_alter('applink_info', $applink);
 
@@ -79,6 +87,7 @@ function app_link_bounce($applink) {
     'platform_data' => drupal_json_encode($applink['platform_data']),
     'fallback_url' => drupal_json_encode($applink['fallback_url']),
     'scripts' => $applink['scripts'],
+    'metatags' => $applink['metatags'],
   ));
 
   // Do not just exit. Rather let Drupal run it's closure functions to

--- a/app_link.module
+++ b/app_link.module
@@ -74,6 +74,15 @@ function app_link_bounce($applink) {
   );
   drupal_alter('applink_info', $applink);
 
+  $no_fallback_url = url('', array('absolute' => TRUE));
+  if (!empty($applink['platform_data']['app_link_platform_fallback']['meta_fetch']) &&
+    !empty($applink['fallback_url']) &&
+    ($applink['fallback_url'] !== $no_fallback_url)
+  ) {
+    $metatags = app_link_get_meta_tags($applink['fallback_url']);
+    $applink['metatags'] = array_merge($applink['metatags'], $metatags);
+  }
+
   // Remove the fallback plugins because those don't do client redirections.
   // Those only provide data to generate the fallback URL for other platform
   // plugins.
@@ -371,4 +380,44 @@ function app_link_process_applink($applink) {
     $data['path_whitelist'] = explode("\r\n", $data['path_whitelist']);
   }
   return $applink;
+}
+
+/**
+ * Gets a list Metatags from target page.
+ *
+ * @param string $url
+ *   Url to extract Metatags from.
+ *
+ * @return array
+ *   Array of html strings.
+ */
+function app_link_get_meta_tags($url) {
+  $tags = array();
+  $contents = @file_get_contents($url);
+
+  preg_match('/<head.+<\/head>/sim', $contents, $match1);
+  if (empty($match1)) {
+    return;
+  }
+  $head = $match1[0];
+
+  preg_match('/<title.+<\/title>/si', $head, $match2);
+  if (!empty($match2[0])) {
+    $tags[] = $match2[0];
+  }
+
+  // Grab Meta tags and Link canonical.
+  preg_match_all('/<(meta|link) [^>]+>/si', $head, $match3);
+  if (!empty($match3[0])) {
+    foreach ($match3[0] as $tag) {
+      // Filter presentation tags out.
+      if (strpos($tag, 'rel="stylesheet"') === FALSE &&
+        strpos($tag, 'charset=') === FALSE &&
+        strpos($tag, 'viewport') === FALSE) {
+        $tags[] = $tag;
+      }
+    }
+  }
+
+  return $tags;
 }

--- a/platforms/app_link_platform_fallback.inc
+++ b/platforms/app_link_platform_fallback.inc
@@ -37,17 +37,6 @@ function app_link_platform_fallback_form(array $conf = array()) {
     '#maxlength' => 2000,
     '#required' => FALSE,
     '#default_value' => isset($conf['fallback_url']) ? $conf['fallback_url'] : '',
-    '#states' => array(
-      'invisible' => array(
-        ':input[name="platform_data[app_link_platform_fallback][override]"]' => array('checked' => FALSE),
-      ),
-    ),
-  );
-  $form['override'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Show path'),
-    '#description' => t('Show the text field to manually set the path.'),
-    '#default_value' => empty($conf['fallback_url']),
   );
   app_link_qs_path_form($conf, $form);
 

--- a/platforms/app_link_platform_fallback.inc
+++ b/platforms/app_link_platform_fallback.inc
@@ -38,6 +38,12 @@ function app_link_platform_fallback_form(array $conf = array()) {
     '#required' => FALSE,
     '#default_value' => isset($conf['fallback_url']) ? $conf['fallback_url'] : '',
   );
+  $form['meta_fetch'] = array(
+    '#title' => t('Acquire Meta Tags from Fallback'),
+    '#description' => t('Request metatags from Fallback URL on App Link page.'),
+    '#type' => 'checkbox',
+    '#default_value' => isset($conf['meta_fetch']) ? $conf['meta_fetch'] : FALSE,
+  );
   app_link_qs_path_form($conf, $form);
   return $form;
 }

--- a/platforms/app_link_platform_fallback.inc
+++ b/platforms/app_link_platform_fallback.inc
@@ -39,9 +39,5 @@ function app_link_platform_fallback_form(array $conf = array()) {
     '#default_value' => isset($conf['fallback_url']) ? $conf['fallback_url'] : '',
   );
   app_link_qs_path_form($conf, $form);
-
-  // Support qs and path by default.
-  $form['supports_qs']['#default_value'] = isset($conf['supports_qs']) ? $conf['supports_qs'] : TRUE;
-  $form['supports_path']['#default_value'] = isset($conf['supports_path']) ? $conf['supports_qs'] : TRUE;
   return $form;
 }

--- a/templates/app-link.tpl.php
+++ b/templates/app-link.tpl.php
@@ -20,8 +20,9 @@
 ?><!DOCTYPE html>
 <html>
 <head>
-<meta charset="utf-8">
-<title><?php print t('Mobile App'); ?></title>
+<?php foreach ($metatags as $metatag) : ?>
+  <?php print $metatag ?>
+<?php endforeach; ?>
 </head>
 <body>
 


### PR DESCRIPTION
As a social media user, I want the app-link pages to support the rich metadata that would allow Facebook/Twitter to dynamically construct a rich social post to increase user engagement with social content. The app-links don't include any header metadata, which means that the posts are simply a web-link unless manually adjusted using power-editor.
- Provides checkbox to fetch metatags from fallback source.
- Security prevention to only fetch form current domain
- Still we should be careful!
