### PR TITLE
Mac and Windows App/Store aupport

### DIFF
--- a/app_link.module
+++ b/app_link.module
@@ -135,8 +135,8 @@ function app_link_bounce($applink) {
 
   // Merge Platform JS info data.
   $platforms = array();
-  foreach ($applink['platform_info'] as $id => &$platform) {
-    $platforms[$id] = array_merge($applink['platform_info'][$id]['js'], $applink['platform_data'][$id]);
+  foreach ($applink['platform_info'] as $id => $platform) {
+    $platforms[$id] = $applink['platform_data'][$id];
   }
 
   drupal_add_http_header('Content-Type', 'text/html; charset=utf-8');
@@ -178,13 +178,60 @@ function app_link_ctools_export_ui_form(&$form, &$form_state) {
   $platforms = ctools_get_plugins('app_link', 'platform');
   uasort($platforms, 'ctools_plugin_sort');
   foreach ($platforms as $id => $platform) {
-    if ($platform['form']) {
-      $form_callback = $platform['form'];
-      $platform_data = isset($applink->platform_data[$id]) ? $applink->platform_data[$id] : array();
-      $form['platform_data'][$id] = $form_callback($platform_data);
-    }
+    $form_callback = !empty($platform['form']) ? $platform['form'] : 'app_link_platform_form';
+    $platform_data = !empty($applink->platform_data[$id]) ? $applink->platform_data[$id] : array();
+    $form['platform_data'][$id] = $form_callback($platform, $platform_data);
   }
 
+  return $form;
+}
+
+/**
+ * Construct a Drupal form for the platform parameters.
+ *
+ * @param array $platform
+ *   An array of information about plaform.
+ * @param array $conf
+ *   An array of existing configurations.
+ *
+ * @return array
+ *   A Drupal form structure.
+ */
+function app_link_platform_form($platform, array $conf = array()) {
+  $form = array(
+    '#type' => 'fieldset',
+    '#title' => $platform['title'],
+    '#collapsible' => TRUE,
+    '#collapsed' => FALSE,
+    '#tree' => TRUE,
+  );
+  $form['app_url'] = array(
+    '#title' => t('App URL Scheme'),
+    '#description' => t('URL Scheme of the @title to redirect to', array(
+      '@title' => $platform['title'],
+    )),
+    '#attributes' => array('placeholder' => 'myapp://'),
+    '#type' => 'textfield',
+    '#element_validate' => array('app_link_valid_url_scheme'),
+    '#maxlength' => 2000,
+    '#required' => FALSE,
+    '#default_value' => isset($conf['app_url']) ? $conf['app_url'] : '',
+  );
+  $form['store_url'] = array(
+    '#title' => t('Store Page on @store_title', array(
+      '@store_title' => $platform['store_title'],
+    )),
+    '#description' => t('URL where you can download the App.', array(
+      '@store_title' => $platform['store_title'],
+    )),
+    '#attributes' => array('placeholder' => $platform['store_pattern']),
+    '#type' => 'textfield',
+    '#element_validate' => array('app_link_valid_url'),
+    '#maxlength' => 2000,
+    '#required' => FALSE,
+    '#default_value' => isset($conf['store_url']) ? $conf['store_url'] : '',
+  );
+  app_link_qs_path_form($conf, $form);
   return $form;
 }
 
@@ -217,6 +264,17 @@ function app_link_valid_id($element, &$form_state) {
 function app_link_valid_url_scheme($element, &$form_state) {
   if (!empty($element['#value']) && !preg_match('#^[a-z][a-z0-9\+\.\-]+://#', $element['#value'])) {
     form_error($element, t('The @field is an invalid URL Scheme', array(
+      '@field' => $element['#title'],
+    )));
+  }
+}
+
+/**
+ * Ensures that, if a value is entered, it is a valid Intent URL.
+ */
+function app_link_valid_intent($element, &$form_state) {
+  if (!empty($element['#value']) && !preg_match('#^intent://#', $element['#value'])) {
+    form_error($element, t('The @field is an invalid Android Intent URL', array(
       '@field' => $element['#title'],
     )));
   }

--- a/platforms/app_link_platform_android.inc
+++ b/platforms/app_link_platform_android.inc
@@ -8,36 +8,37 @@ global $language;
 
 $plugin = array(
   'title' => t('Android App'),
-  'js' => array(
-    'router' => 'android',
-    'match' => 'Android',
-    'not_match' => 'Kindle|Windows Phone',
-  ),
   'form' => 'app_link_platform_android_form',
   'badge_url' => '//developer.android.com/images/brand/' . $language->language . '_generic_rgb_wo_60.png',
   'store_text' => t('Get it on Google Play'),
+  'store_title' => t('Google Play'),
+  'store_pattern' => 'https://play.google.com/store/apps/details/?id=<package_name>',
 );
 
 /**
- * Construct a Drupal form for Android platform parameters.
+ * Construct a Drupal form for the platform parameters.
  *
+ * @param array $platform
+ *   An array of information about plaform.
  * @param array $conf
  *   An array of existing configurations.
  *
  * @return array
  *   A Drupal form structure.
  */
-function app_link_platform_android_form(array $conf = array()) {
+function app_link_platform_android_form(array $platform, array $conf = array()) {
   $form = array(
     '#type' => 'fieldset',
-    '#title' => t('Android App'),
+    '#title' => $platform['title'],
     '#collapsible' => TRUE,
     '#collapsed' => FALSE,
     '#tree' => TRUE,
   );
   $form['app_url'] = array(
     '#title' => t('App URL Scheme'),
-    '#description' => t('URL Scheme of the Android App to redirect to'),
+    '#description' => t('URL Scheme of the @title to redirect to', array(
+      '@title' => $platform['title'],
+    )),
     '#attributes' => array('placeholder' => 'myapp://'),
     '#type' => 'textfield',
     '#element_validate' => array('app_link_valid_url_scheme'),
@@ -47,18 +48,24 @@ function app_link_platform_android_form(array $conf = array()) {
   );
   $form['intent_url'] = array(
     '#title' => t('App Intent URL'),
-    '#description' => t('The Android Intent URL to direct Android 4.x Chrome to'),
+    '#description' => t('Intent URL of the @title to direct Android 4.x Chrome to', array(
+      '@title' => $platform['title'],
+    )),
     '#attributes' => array('placeholder' => 'intent://scan/#Intent;scheme=zxing;package=com.google.zxing.client.android;end'),
     '#type' => 'textfield',
-    '#element_validate' => array('app_link_platform_android_valid_intent'),
+    '#element_validate' => array('app_link_valid_intent'),
     '#maxlength' => 2000,
     '#required' => FALSE,
     '#default_value' => isset($conf['intent_url']) ? $conf['intent_url'] : '',
   );
   $form['store_url'] = array(
-    '#title' => t('App Page on Google Play'),
-    '#description' => t('The URL where you can download App lives in Google Play.'),
-    '#attributes' => array('placeholder' => 'https://play.google.com/store/apps/details/?id=<package_name>'),
+    '#title' => t('Store Page on @store_title', array(
+      '@store_title' => $platform['store_title'],
+    )),
+    '#description' => t('URL where you can download the App.', array(
+      '@store_title' => $platform['store_title'],
+    )),
+    '#attributes' => array('placeholder' => $platform['store_pattern']),
     '#type' => 'textfield',
     '#element_validate' => array('app_link_valid_url'),
     '#maxlength' => 2000,
@@ -67,15 +74,4 @@ function app_link_platform_android_form(array $conf = array()) {
   );
   app_link_qs_path_form($conf, $form);
   return $form;
-}
-
-/**
- * Ensures that, if a value is entered, it is a valid Android Intent identifier.
- */
-function app_link_platform_android_valid_intent($element, &$form_state) {
-  if (!empty($element['#value']) && !preg_match('#^intent://#', $element['#value'])) {
-    form_error($element, t('The @field is an invalid Android Intent URL', array(
-      '@field' => $element['#title'],
-    )));
-  }
 }

--- a/platforms/app_link_platform_fallback.inc
+++ b/platforms/app_link_platform_fallback.inc
@@ -7,23 +7,24 @@
 $plugin = array(
   'title' => t('Web Fallback'),
   'form' => 'app_link_platform_fallback_form',
-  'js' => array(),
   'weight' => -10,
 );
 
 /**
- * Construct a Drupal form for the web platform parameters.
+ * Construct a Drupal form for the platform parameters.
  *
+ * @param array $platform
+ *   An array of information about plaform.
  * @param array $conf
  *   An array of existing configurations.
  *
  * @return array
  *   A Drupal form structure.
  */
-function app_link_platform_fallback_form(array $conf = array()) {
+function app_link_platform_fallback_form(array $platform, array $conf = array()) {
   $form = array(
     '#type' => 'fieldset',
-    '#title' => t('Web Fallback'),
+    '#title' => $platform['title'],
     '#collapsible' => TRUE,
     '#collapsed' => FALSE,
     '#tree' => TRUE,

--- a/platforms/app_link_platform_ipad.inc
+++ b/platforms/app_link_platform_ipad.inc
@@ -6,52 +6,8 @@
 
 $plugin = array(
   'title' => t('iPad App'),
-  'js' => array(
-    'router' => 'iphone',
-    'match' => 'iPad',
-  ),
-  'form' => 'app_link_platform_ipad_form',
   'badge_url' => '//linkmaker.itunes.apple.com/images/badges/en-us/badge_appstore-lrg.png',
   'store_text' => t('Download from App Store'),
+  'store_title' => t('App Store'),
+  'store_pattern' => 'itms://itunes.apple.com/us/app/',
 );
-
-/**
- * Helper function to construct a Drupal form for iPad platform parameters.
- *
- * @param array $conf
- *   An array of existing configurations.
- *
- * @return array
- *   A Drupal form structure.
- */
-function app_link_platform_ipad_form(array $conf = array()) {
-  $form = array(
-    '#type' => 'fieldset',
-    '#title' => t('iPad App'),
-    '#collapsible' => TRUE,
-    '#collapsed' => FALSE,
-    '#tree' => TRUE,
-  );
-  $form['app_url'] = array(
-    '#title' => t('App URL Scheme'),
-    '#description' => t('URL Scheme of the iPad App to redirect to'),
-    '#attributes' => array('placeholder' => 'myapp://'),
-    '#type' => 'textfield',
-    '#element_validate' => array('app_link_valid_url_scheme'),
-    '#maxlength' => 2000,
-    '#required' => FALSE,
-    '#default_value' => isset($conf['app_url']) ? $conf['app_url'] : '',
-  );
-  $form['store_url'] = array(
-    '#title' => t('App Store Url'),
-    '#description' => t('URL to where the iPad App lives in the App Store'),
-    '#attributes' => array('placeholder' => 'itms://itunes.apple.com/us/app/'),
-    '#type' => 'textfield',
-    '#element_validate' => array('app_link_valid_url'),
-    '#maxlength' => 2000,
-    '#required' => FALSE,
-    '#default_value' => isset($conf['store_url']) ? $conf['store_url'] : '',
-  );
-  app_link_qs_path_form($conf, $form);
-  return $form;
-}

--- a/platforms/app_link_platform_kindle_fire.inc
+++ b/platforms/app_link_platform_kindle_fire.inc
@@ -6,52 +6,8 @@
 
 $plugin = array(
   'title' => t('Kindle Fire App'),
-  'js' => array(
-    'router' => 'iphone',
-    'match' => 'Kindle',
-  ),
-  'form' => 'app_link_platform_kindle_fire_form',
   'badge_url' => '//g-ec2.images-amazon.com/images/G/01/DevMarketing/amazon-apps-kindle-us-black._V306408287_.png',
   'store_text' => t('Available at Amazon'),
+  'store_title' => t("Amazon's Fire Store"),
+  'store_pattern' => 'http://www.amazon.com/gp/product/<product_id>',
 );
-
-/**
- * Construct a Drupal form for Kindle Fire platform parameters.
- *
- * @param array $conf
- *   An array of existing configurations.
- *
- * @return array
- *   A Drupal form structure.
- */
-function app_link_platform_kindle_fire_form(array $conf = array()) {
-  $form = array(
-    '#type' => 'fieldset',
-    '#title' => t('Kindle Fire App'),
-    '#collapsible' => TRUE,
-    '#collapsed' => FALSE,
-    '#tree' => TRUE,
-  );
-  $form['app_url'] = array(
-    '#title' => t('App URL Scheme'),
-    '#description' => t('URL Scheme of the Kindle Fire App to redirect to'),
-    '#attributes' => array('placeholder' => 'myapp://'),
-    '#type' => 'textfield',
-    '#element_validate' => array('app_link_valid_url_scheme'),
-    '#maxlength' => 2000,
-    '#required' => FALSE,
-    '#default_value' => isset($conf['app_url']) ? $conf['app_url'] : '',
-  );
-  $form['store_url'] = array(
-    '#title' => t('App Page on Amazon'),
-    '#description' => t('The URL where you can download App lives in Amazon\'s Fire Store.'),
-    '#attributes' => array('placeholder' => 'http://www.amazon.com/gp/product/<product_id>'),
-    '#type' => 'textfield',
-    '#element_validate' => array('app_link_valid_url'),
-    '#maxlength' => 2000,
-    '#required' => FALSE,
-    '#default_value' => isset($conf['store_url']) ? $conf['store_url'] : '',
-  );
-  app_link_qs_path_form($conf, $form);
-  return $form;
-}

--- a/platforms/app_link_platform_mac.inc
+++ b/platforms/app_link_platform_mac.inc
@@ -1,13 +1,13 @@
 <?php
 /**
  * @file
- * App Link plugin to define iPhone App.
+ * App Link plugin to define Mac App.
  */
 
 $plugin = array(
-  'title' => t('iPhone App'),
+  'title' => t('Mac App'),
   'badge_url' => '//linkmaker.itunes.apple.com/images/badges/en-us/badge_appstore-lrg.png',
   'store_text' => t('Download from App Store'),
-  'store_title' => t('App Store'),
+  'store_title' => t('Mac App Store'),
   'store_pattern' => 'itms://itunes.apple.com/us/app/',
 );

--- a/platforms/app_link_platform_windows.inc
+++ b/platforms/app_link_platform_windows.inc
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @file
+ * App Link plugin to define Windows App.
+ */
+
+global $language;
+
+$plugin = array(
+  'title' => t('Windows App'),
+  'badge_url' => '//cmsresources.windowsphone.com/devcenter/en-us/legacy_v1/img/badgegenerator/' . $language->name . '_wstore_cyan_258x67.png',
+  'store_text' => t('Download from Windows Store'),
+  'store_title' => t('Windows Store'),
+  'store_pattern' => 'https://www.microsoft.com/en-us/store/apps/<product-code>/<product-id>',
+);

--- a/platforms/app_link_platform_windows_phone.inc
+++ b/platforms/app_link_platform_windows_phone.inc
@@ -8,52 +8,8 @@ global $language;
 
 $plugin = array(
   'title' => t('Windows Phone App'),
-  'js' => array(
-    'router' => 'iphone',
-    'match' => 'Windows Phone',
-  ),
-  'form' => 'app_link_platform_windows_phone_form',
   'badge_url' => '//cmsresources.windowsphone.com/devcenter/en-us/legacy_v1/img/badgegenerator/' . $language->name . '_wphone_cyan_258x67.png',
   'store_text' => t('Download from Windows Store'),
+  'store_title' => t('Windows Phone Store'),
+  'store_pattern' => 'https://www.windowsphone.com/en-us/store/app/<product-code>/<product-id>',
 );
-
-/**
- * Construct a Drupal form for Windows Phone platform parameters.
- *
- * @param array $conf
- *   An array of existing configurations.
- *
- * @return array
- *   A Drupal form structure.
- */
-function app_link_platform_windows_phone_form(array $conf = array()) {
-  $form = array(
-    '#type' => 'fieldset',
-    '#title' => t('Windows Phone App'),
-    '#collapsible' => TRUE,
-    '#collapsed' => FALSE,
-    '#tree' => TRUE,
-  );
-  $form['app_url'] = array(
-    '#title' => t('App URL Scheme'),
-    '#description' => t('URL Scheme of the Windows Phone App to redirect to'),
-    '#attributes' => array('placeholder' => 'myapp://'),
-    '#type' => 'textfield',
-    '#element_validate' => array('app_link_valid_url_scheme'),
-    '#maxlength' => 2000,
-    '#required' => FALSE,
-    '#default_value' => isset($conf['app_url']) ? $conf['app_url'] : '',
-  );
-  $form['store_url'] = array(
-    '#title' => t('App Page on the Windows Phone Store'),
-    '#description' => t('The URL where you can download the App in the Windows Phone Store'),
-    '#attributes' => array('placeholder' => 'http://www.windowsphone.com/en-us/store/app/<product-code>/<product-id>'),
-    '#type' => 'textfield',
-    '#element_validate' => array('app_link_valid_url'),
-    '#maxlength' => 2000,
-    '#required' => FALSE,
-    '#default_value' => isset($conf['store_url']) ? $conf['store_url'] : '',
-  );
-  app_link_qs_path_form($conf, $form);
-  return $form;
-}

--- a/test/app_link.js
+++ b/test/app_link.js
@@ -18,7 +18,13 @@ var USERAGENTS = {
   "Android Browser": "Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30",
   "Android Chrome": "Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19",
   "Windows Phone": "Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 920)",
-  "Kindle Fire": "Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; Kindle Fire Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1"
+  "Kindle Fire": "Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; Kindle Fire Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1",
+  "OSX Safari": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/7.1.7 Safari/537.85.16",
+  "OSX Chrome": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.134 Safari/537.36",
+  "OSX Firefox": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:38.0) Gecko/20100101 Firefox/38.0",
+  "Windows Explorer": "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)",
+  "Windows Chrome": "Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1667.0 Safari/537.36",
+  "Windows Firefox": "Mozilla/5.0 (Windows NT 6.2; Win64; x64; rv:27.0) Gecko/20121011 Firefox/27.0"
 };
 
 describe("App Link Redirects", function() {
@@ -183,6 +189,12 @@ describe("App Link Redirects", function() {
   testPlatform("Android Chrome", "app_link_platform_android");
   testPlatform("Windows Phone", "app_link_platform_windows_phone");
   testPlatform("Kindle Fire", "app_link_platform_kindle_fire");
+  testPlatform("OSX Safari", "app_link_platform_mac");
+  testPlatform("OSX Chrome", "app_link_platform_mac");
+  testPlatform("OSX Firefox", "app_link_platform_mac");
+  testPlatform("Windows Explorer", "app_link_platform_windows");
+  testPlatform("Windows Chrome", "app_link_platform_windows");
+  testPlatform("Windows Firefox", "app_link_platform_windows");
  
   /**
    * Limit scope to distinct cases: URI Schemes (most) & Intent URLs (Android)

--- a/test/fixtures/example-platforms.json
+++ b/test/fixtures/example-platforms.json
@@ -6,9 +6,6 @@
         "path_whitelist": []
     },
     "app_link_platform_android": {
-        "router": "android",
-        "match": "Android",
-        "not_match": "Kindle|Windows Phone",
         "app_url": "android-nbctve://",
         "intent_url": "intent://live#Intent;scheme=nbctve;package=com.nbcuni.nbc;end",
         "store_url": "https://play.google.com/store/apps/details?id=com.nbcuni.nbc&hl=en",
@@ -17,8 +14,6 @@
         "path_whitelist": []
     },
     "app_link_platform_ipad": {
-        "router": "iphone",
-        "match": "iPad",
         "app_url": "ipad-nbctve://",
         "store_url": "https://itunes.apple.com/us/app/nbc-watch-live-tv-now-stream/id442839435?mt=8",
         "supports_qs": 0,
@@ -26,9 +21,6 @@
         "path_whitelist": []
     },
     "app_link_platform_iphone": {
-        "router": "iphone",
-        "match": "iPhone|iPod",
-        "not_match": "Windows Phone",
         "app_url": "iphone-nbctve://",
         "store_url": "https://itunes.apple.com/us/app/nbc-watch-live-tv-now-stream/id442839435?mt=8",
         "supports_qs": 0,
@@ -36,8 +28,6 @@
         "path_whitelist": []
     },
     "app_link_platform_kindle_fire": {
-        "router": "iphone",
-        "match": "Kindle",
         "app_url": "kindle-nbctve://",
         "store_url": "http://www.amazon.com/NBC-News-Digital-LLC/dp/B0055DL1G4",
         "supports_qs": 0,
@@ -45,10 +35,22 @@
         "path_whitelist": []
     },
     "app_link_platform_windows_phone": {
-        "router": "iphone",
-        "match": "Windows Phone",
         "app_url": "winmo-nbctve://",
         "store_url": "http://www.windowsphone.com/en-us/store/app/nbc-sports-live-extra/2bfb700d-7703-45ac-818e-677857b3b849",
+        "supports_qs": 0,
+        "supports_path": 0,
+        "path_whitelist": []
+    },
+    "app_link_platform_mac": {
+        "app_url": "mac-nbctve://",
+        "store_url": "https://itunes.apple.com/us/app/nbc-watch-live-tv-now-stream/id442839435?mt=8",
+        "supports_qs": 0,
+        "supports_path": 0,
+        "path_whitelist": []
+    },
+    "app_link_platform_windows": {
+        "app_url": "windows-nbctve://",
+        "store_url": "https://www.microsoft.com/en-us/store/apps/nbc-news/9wzdncrfj2r4",
         "supports_qs": 0,
         "supports_path": 0,
         "path_whitelist": []


### PR DESCRIPTION
Supporting Desktops (OS X Snow Leopard+ and Windows 8) is a bit more complex…
- We had to scrap defining reg-ex's in php-land. I don't think anyone was using it, but Drupal users may have like the integration.
- In any case, this makes our front-end JS code less tied to the Drupal module :smiling_imp:
